### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: Build Project
+permissions:
+  contents: read
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/CMakeDockerTemplate/security/code-scanning/3](https://github.com/gvatsal60/CMakeDockerTemplate/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only requires read access to repository contents (e.g., for the `actions/checkout` step), the permissions should be set to `contents: read`. This ensures the `GITHUB_TOKEN` has the least privilege necessary to complete the tasks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
