### PR TITLE
Fixed SonarQube Issues

### DIFF
--- a/cmakedockertemplate/lib/memlib/inc/memlib.h
+++ b/cmakedockertemplate/lib/memlib/inc/memlib.h
@@ -7,12 +7,10 @@
 
 template <typename T> static void MemClean(const T *const arg) {
   assert(arg != nullptr);
-  std::unique_ptr<const T> argPtr(arg);
 }
 
 template <typename T> static void MemArrClean(const T *const arg) {
   assert(arg != nullptr);
-  std::unique_ptr<const T[]> argPtr(arg);
 }
 
 #endif


### PR DESCRIPTION
This pull request makes a minor update to memory cleanup functions in `memlib.h`. The main change is the removal of unused `std::unique_ptr` declarations from the `MemClean` and `MemArrClean` template functions.

Memory management cleanup:

* Removed unnecessary `std::unique_ptr` declarations from the `MemClean` and `MemArrClean` template functions in `memlib.h`. This simplifies the functions and avoids creating unused smart pointers.